### PR TITLE
Fix code style

### DIFF
--- a/rel_imp.py
+++ b/rel_imp.py
@@ -1,4 +1,4 @@
-'''
+"""
 Copyright (c) 2014 Joaquin Duo - File under MIT License
 
 Import this module to enable explicit relative importing on a submodule or
@@ -17,7 +17,7 @@ this package before any relative import
 
 Make sure your PYTHONPATH is correctly set to solve the relative path of the
 submodule/subpackage.
-'''
+"""
 from inspect import currentframe
 from os import path
 import importlib
@@ -25,17 +25,16 @@ import sys
 import os
 import traceback
 
-
 __all__ = ['init']
 
 
 def _get_search_path(main_file_dir, sys_path):
-    '''
+    """
     Find the parent python path that contains the __main__'s file directory
 
     :param main_file_dir: __main__'s file directory
     :param sys_path: paths list to match directory against (like sys.path)
-    '''
+    """
     # List to gather candidate parent paths
     paths = []
     # look for paths containing the directory
@@ -55,17 +54,17 @@ def _get_search_path(main_file_dir, sys_path):
 
 
 def _print_exc(e):
-    '''
+    """
     Log exception as error.
     :param e: exception to be logged.
-    '''
+    """
     msg = ('Exception enabling relative_import for __main__. Ignoring it: %r'
            '\n  relative_import won\'t be enabled.')
     _log_error(msg % e)
 
 
 def _try_search_paths(main_globals):
-    '''
+    """
     Try different strategies to found the path containing the __main__'s file.
     Will try strategies, in the following order:
         1. Building file's path with PWD env var.
@@ -73,7 +72,7 @@ def _try_search_paths(main_globals):
         3. Buidling file's path from real file's path.
 
     :param main_globals: globals dictionary in __main__
-    '''
+    """
     # try with abspath
     fl = main_globals['__file__']
     search_path = None
@@ -148,19 +147,19 @@ def _solve_pkg(main_globals):
 
 
 def _log(msg):
-    '''
+    """
     Central log function (all levels)
     :param msg: message to log
-    '''
+    """
     sys.stderr.write(msg + '\n')
     sys.stderr.flush()
 
 
 def _log_debug(msg):
-    '''
+    """
     Log at debug level
     :param msg: message to log
-    '''
+    """
     if _log_level <= DEBUG:
         if _log_level == TRACE:
             traceback.print_stack()
@@ -168,10 +167,10 @@ def _log_debug(msg):
 
 
 def _log_error(msg):
-    '''
+    """
     Log at error level
     :param msg: message to log
-    '''
+    """
     if _log_level <= ERROR:
         _log(msg)
 
@@ -180,6 +179,7 @@ def _log_error(msg):
 ERROR = 40
 DEBUG = 10
 TRACE = 5
+
 # Set default level
 _log_level = ERROR
 
@@ -188,12 +188,12 @@ _initialized = False
 
 
 def init(log_level=ERROR):
-    '''
+    """
     Enables explicit relative import in sub-modules when ran as __main__
     :param log_level: module's inner logger level (equivalent to logging pkg)
 
     Use PYTHON_DISABLE_REL_IMP environment variable to disable the initialization
-    '''
+    """
     global _initialized
     if _initialized:
         _log_debug('Initialized. Doing nothing')
@@ -211,9 +211,9 @@ def init(log_level=ERROR):
 
 
 def init_implicitly(log_level=ERROR):
-    '''
+    """
     Use PYTHON_DISABLE_REL_IMP environment variable to disable the initialization
-    '''
+    """
     global _initialized
     if _initialized:
         _log_debug('Initialized. Doing nothing')
@@ -231,10 +231,10 @@ def init_implicitly(log_level=ERROR):
 
 
 def _init(frame, log_level=ERROR):
-    '''
+    """
     Enables explicit relative import in sub-modules when ran as __main__
     :param log_level: module's inner logger level (equivalent to logging pkg)
-    '''
+    """
     global _log_level
     _log_level = log_level
     # now we have access to the module globals

--- a/rel_imp_tests/package_test_parent/__init__.py
+++ b/rel_imp_tests/package_test_parent/__init__.py
@@ -1,9 +1,11 @@
-'''
-
-'''
+"""
+Package test parent
+"""
 import unittest
 import rel_imp
+
 rel_imp.init(log_level=rel_imp.DEBUG)
+
 from ..relimported1 import example_function
 
 
@@ -13,6 +15,7 @@ class TestRelativeImport(unittest.TestCase):
         example_function()
         from ..relimported2 import example_function as ex2
         ex2()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rel_imp_tests/package_test_parent_init_implicitly/__init__.py
+++ b/rel_imp_tests/package_test_parent_init_implicitly/__init__.py
@@ -1,8 +1,7 @@
-'''
-
-'''
+"""
+Test parent init implicit.
+"""
 import unittest
-import relative_import
 from ..relimported1 import example_function
 
 
@@ -12,6 +11,7 @@ class TestRelativeImport(unittest.TestCase):
         example_function()
         from ..relimported2 import example_function as ex2
         ex2()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rel_imp_tests/relimported1.py
+++ b/rel_imp_tests/relimported1.py
@@ -1,7 +1,2 @@
-'''
-
-'''
-
-
 def example_function():
     return 'this is an example'

--- a/rel_imp_tests/relimported2.py
+++ b/rel_imp_tests/relimported2.py
@@ -1,7 +1,2 @@
-'''
-
-'''
-
-
 def example_function():
     return 'this is an example'

--- a/rel_imp_tests/test_global_import.py
+++ b/rel_imp_tests/test_global_import.py
@@ -1,9 +1,10 @@
-'''
-
-'''
+"""
+Test global import
+"""
 import unittest
 
 import rel_imp
+
 rel_imp.init()
 from .relimported1 import example_function
 
@@ -14,6 +15,7 @@ class TestRelativeImport(unittest.TestCase):
         example_function()
         from .relimported2 import example_function as ex2
         ex2()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rel_imp_tests/test_global_import_debug.py
+++ b/rel_imp_tests/test_global_import_debug.py
@@ -1,15 +1,17 @@
-'''
-
-'''
+"""
+Test global import debug.
+"""
 import unittest
 
 import rel_imp
+
 rel_imp.init(log_level=rel_imp.DEBUG)
 import rel_imp_tests.test_global_import
 
 
 class TestRelativeImportDebug(rel_imp_tests.test_global_import.TestRelativeImport):
     pass
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rel_imp_tests/test_global_import_init_implicitly.py
+++ b/rel_imp_tests/test_global_import_init_implicitly.py
@@ -1,6 +1,6 @@
-'''
-
-'''
+"""
+Test global import init implicitly
+"""
 import unittest
 
 import relative_import  # @UnusedImport
@@ -13,6 +13,7 @@ class TestRelativeImport(unittest.TestCase):
         example_function()
         from .relimported2 import example_function as ex2
         ex2()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rel_imp_tests/test_local_import.py
+++ b/rel_imp_tests/test_local_import.py
@@ -1,6 +1,6 @@
-'''
-
-'''
+"""
+Test local import
+"""
 import imp
 import unittest
 import rel_imp
@@ -27,5 +27,7 @@ class TestRelativeImport(unittest.TestCase):
         rel_imp = imp.reload(rel_imp)
         rel_imp.init(self._log_level)
 
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/rel_imp_tests/test_local_import_debug.py
+++ b/rel_imp_tests/test_local_import_debug.py
@@ -1,6 +1,6 @@
-'''
-
-'''
+"""
+Test local import debug
+"""
 import unittest
 import rel_imp_tests.test_local_import
 import rel_imp
@@ -8,6 +8,7 @@ import rel_imp
 
 class TestRelativeImport(rel_imp_tests.test_local_import.TestRelativeImport):
     _log_level = rel_imp.DEBUG
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rel_imp_tests/unittest_discover/test_global_import.py
+++ b/rel_imp_tests/unittest_discover/test_global_import.py
@@ -1,9 +1,10 @@
-'''
-
-'''
+"""
+Test global import
+"""
 import unittest
 
 import rel_imp
+
 rel_imp.init()
 from ..relimported1 import example_function
 
@@ -14,6 +15,7 @@ class TestRelativeImport(unittest.TestCase):
         example_function()
         from ..relimported2 import example_function as ex2
         ex2()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/relative_import.py
+++ b/relative_import.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Copyright (c) 2015 Joaquin Duo - File under MIT License
 
 Code Licensed under MIT License. See LICENSE file.
@@ -20,7 +20,7 @@ this package before any relative import
 There is no need to call any init function using this module.
 Make sure your PYTHONPATH is correctly set to solve the relative path of the
 submodule/subpackage.
-'''
+"""
 
 import rel_imp
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,9 @@ name = 'rel_imp'
 def in_python3():
     return sys.version_info[0] > 2
 
+
 def long_description():
-    with open('README', 'r') as f:
+    with open('README.md', 'r') as f:
         if in_python3():
             return f.read()
         else:


### PR DESCRIPTION
**Description:**

This pull request is about code style and does not add any feature.

**Dev Notes:**

- [Suggest] We replaced single quotes with double quotes. The most important is consistency, and we can see there is consistency using single quotes; anyway, triple quotes are the preferred choice to use in docstring.

- Removed an unused import.

- Some not significant changes about PEP8 and missing blank space at the end of the file.